### PR TITLE
feat: Add robustness tests and fix catalog bug

### DIFF
--- a/py_name_entity_recognition/catalog.py
+++ b/py_name_entity_recognition/catalog.py
@@ -648,6 +648,13 @@ def get_schema(
 
     # 3. Add specific entities
     if include_entities:
+        # Validate that all included entities exist in the registry
+        unknown_entities = set(include_entities) - set(ENTITY_REGISTRY.keys())
+        if unknown_entities:
+            raise ValueError(
+                "The following entities from 'include_entities' are not in the registry: "
+                f"{', '.join(sorted(list(unknown_entities)))}"  # Sort for consistent error messages
+            )
         selected_entity_keys.update(include_entities)
         logger.info(f"Included {len(include_entities)} specific entities.")
 


### PR DESCRIPTION
This commit adds several new robustness tests to the NER engine and the catalog system.

New tests include:
- Disambiguation of entities based on context (e.g., "Washington" as a person vs. location).
- Handling of input text that contains no entities matching the schema.
- Verification of catalog behavior with invalid or combined options, such as excluding entities from a category.

A bug was discovered and fixed in the `catalog.get_schema` function where providing a non-existent entity in `include_entities` would not raise an error. The function now correctly validates all entities against the registry and raises a `ValueError` for unknown entities.